### PR TITLE
Add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,89 @@
+name: 7s-claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    branches: # Only run on PRs targeting master/main
+      - master
+      - main
+
+jobs:
+  rabbit-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_7S_SANDBOX }}:role/github
+          role-session-name: ${{ github.job }}
+          aws-region: eu-central-1
+
+      - name: Create MCP Config
+        env:
+          JIRA_URL: ${{ vars.JIRA_URL }}
+          JIRA_EMAIL: ${{ vars.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          cat > /tmp/mcp-config.json << EOF
+          {
+            "mcpServers": {
+              "mcp-atlassian": {
+                "command": "docker",
+                "args": [
+                  "run",
+                  "-i",
+                  "--rm",
+                  "-e", "JIRA_URL",
+                  "-e", "JIRA_USERNAME",
+                  "-e", "JIRA_API_TOKEN",
+                  "ghcr.io/sooperset/mcp-atlassian:latest"
+                ],
+                "env": {
+                  "JIRA_URL": "${JIRA_URL}",
+                  "JIRA_USERNAME": "${JIRA_EMAIL}",
+                  "JIRA_API_TOKEN": "${JIRA_API_TOKEN}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Run 7s-rabbit Code Review
+        id: rabbit-review
+        uses: anthropics/claude-code-action@v1
+        env:
+          AWS_REGION: eu-central-1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # For AWS Bedrock, don't use claude_code_oauth_token or claude-api-key
+          # Authentication is handled via AWS credentials configured above
+          # When track_progress is enabled:
+          # - Creates a tracking comment with progress checkboxes
+          # - Includes all PR context (comments, attachments, images)
+          # - Updates progress as the review proceeds
+          # - Marks as completed when done
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            ${{ vars.CLAUDE_REVIEW_PROMPT }}
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
+          # Use inference profile for on-demand throughput
+          # Check available profiles: aws bedrock list-inference-profiles --region eu-central-1
+          use_bedrock: "true"
+          claude_args: |
+            --mcp-config /tmp/mcp-config.json --model ${{ vars.CLAUDE_MODEL }} --allowed-tools "mcp__github_inline_comment__create_inline_comment,mcp__mcp-atlassian__jira_get_issue,mcp__mcp-atlassian__jira_search,mcp__mcp-atlassian__jira_get_project_issues,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
## Summary

This PR adds the Claude Code Review GitHub Action workflow to automate code reviews for pull requests.

## What's included

- GitHub Actions workflow that triggers on PRs to main/master
- Automated code review using Claude Code
- AWS Bedrock integration for Claude API access
- MCP integration for Jira and GitHub

## Requirements

The following secrets and variables need to be configured in the repository settings:

**Secrets:**
- `AWS_7S_SANDBOX` - AWS account ID for Bedrock access
- `JIRA_API_TOKEN` - Jira API token for MCP integration

**Variables:**
- `JIRA_URL` - Jira instance URL
- `JIRA_EMAIL` - Jira user email
- `CLAUDE_REVIEW_PROMPT` - Organization-wide prompt for Claude Code Review
- `CLAUDE_MODEL` - Claude model to use (e.g., us.anthropic.claude-sonnet-4-20250514-v1:0)

## Testing

After merging, create a test PR to verify the workflow runs correctly.